### PR TITLE
[ContributorsFromGit] -> [Git::Contributors]

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,7 +10,7 @@ copyright_year   = 2013
 version_regexp = ^release-(.+)$
  
 ; collect contributors list
-[ContributorsFromGit]
+[Git::Contributors]
  
 ; choose files to include
 [Git::GatherDir]         ; everything from git ls-files


### PR DESCRIPTION
This plugin has unresolved issues on MSWin32 and with handling unicode names, so I forked it last year.
